### PR TITLE
fix: compile mostro-cli from source and maintain dependencies order

### DIFF
--- a/docker/mostro/Dockerfile
+++ b/docker/mostro/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     && install target/release/mostro-cli /usr/local/bin \
     && cd .. \
     && rm -rf mostro-cli \
-    # Instalar nak antes de la limpieza
+     # Install nak before cleanup
     && BIN_URL=$(curl -s https://api.github.com/repos/fiatjaf/nak/releases/latest | grep -oP '"browser_download_url":\s*"\K[^"]+' | grep linux-amd64) \
     && TMP_DIR=$(mktemp -d) \
     && cd $TMP_DIR \
@@ -40,7 +40,7 @@ RUN apt-get update && \
     && install ${BIN_URL##*/} /usr/local/bin/nak \
     && cd - \
     && rm -rf $TMP_DIR \
-    # Limpieza para reducir el tamaño de la imagen
+    # clean 
     && apt-get remove -y git build-essential \
     && apt-get autoremove -y \
     && apt-get clean \

--- a/docker/mostro/Dockerfile
+++ b/docker/mostro/Dockerfile
@@ -17,24 +17,35 @@ RUN BIN_URL=$(curl -s https://api.github.com/repos/MostroP2P/mostro/releases/lat
   && rm -rf $TMP_DIR
 
 # install mostro-cli
-RUN BIN_URL=$(curl -s https://api.github.com/repos/MostroP2P/mostro-cli/releases/latest | grep -oP '"browser_download_url":\s*"\K[^"]+' | grep x86_64 | grep linux-musl) \
-  && TMP_DIR=$(mktemp -d) \
-  && cd $TMP_DIR \
-  && curl -SLO $BIN_URL \
-  && tar -xzf ${BIN_URL##*/} \
-  && DIR_NAME=${BIN_URL##*mostro-cli-} && DIR_NAME=${DIR_NAME%.tar.gz} \
-  && install $DIR_NAME/mostro-cli /usr/local/bin \
-  && cd - \
-  && rm -rf $TMP_DIR
-
-# install nak nostr tool
-RUN BIN_URL=$(curl -s https://api.github.com/repos/fiatjaf/nak/releases/latest | grep -oP '"browser_download_url":\s*"\K[^"]+' | grep linux-amd64) \
-  && TMP_DIR=$(mktemp -d) \
-  && cd $TMP_DIR \
-  && curl -SLO $BIN_URL \
-  && install ${BIN_URL##*/} /usr/local/bin/nak \
-  && cd - \
-  && rm -rf $TMP_DIR
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    curl \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && . $HOME/.cargo/env \
+    && git clone https://github.com/MostroP2P/mostro-cli.git \
+    && cd mostro-cli \
+    && cargo build --release \
+    && install target/release/mostro-cli /usr/local/bin \
+    && cd .. \
+    && rm -rf mostro-cli \
+    # Instalar nak antes de la limpieza
+    && BIN_URL=$(curl -s https://api.github.com/repos/fiatjaf/nak/releases/latest | grep -oP '"browser_download_url":\s*"\K[^"]+' | grep linux-amd64) \
+    && TMP_DIR=$(mktemp -d) \
+    && cd $TMP_DIR \
+    && curl -SLO $BIN_URL \
+    && install ${BIN_URL##*/} /usr/local/bin/nak \
+    && cd - \
+    && rm -rf $TMP_DIR \
+    # Limpieza para reducir el tamaño de la imagen
+    && apt-get remove -y git build-essential \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf $HOME/.cargo
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod a+x /entrypoint.sh


### PR DESCRIPTION
## Description
Resolves #3 - Fix Docker container build process for mostro-cli installation

### Changes
- Replaced GitHub release binary download method with compilation from source
- Added Rust toolchain installation using rustup
- Included necessary build dependencies for compiling mostro-cli
- Implemented image size optimization by removing build tools after compilation

### Motivation
- Latest GitHub release (v0.11.0) lacked binary assets
- Ensured ability to install the most recent version of mostro-cli
- Provided a more reliable installation method

### Implementation Details
- Used `cargo build --release` to compile mostro-cli from source
- Installed Rust toolchain via official installation script
- Added build dependencies: git, curl, build-essential, pkg-config, libssl-dev
- Cleaned up build tools and temporary files to reduce image size

### Verification
- Tested compilation process
- Confirmed mostro-cli installation from source

Fixes intermittent Docker build failures related to mostro-cli installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the container build process by compiling a key CLI tool from source.
  - Streamlined installation and cleanup steps to remove unnecessary build dependencies, reducing the final image size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->